### PR TITLE
Change masutaka test branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "29hours"]
 	path = 29hours
-	url = git@github.com:june29/29hours.git
+	url = git@github.com:masutaka/29hours.git


### PR DESCRIPTION
多い時は 2 日に 1 回、29hours が落ちてしまう。

```
/home/masutaka/.rbenv/versions/2.2.2/lib/ruby/2.2.0/openssl/buffering.rb:129:in `sysread': end of file reached (EOFError)
        from /home/masutaka/.rbenv/versions/2.2.2/lib/ruby/2.2.0/openssl/buffering.rb:129:in `readpartial'
        from /opt/masutaka-29hours/shared/29hours/vendor/bundle/ruby/2.2.0/gems/twitter-5.14.0/lib/twitter/streaming/connection.rb:21:in `stream'
        from /opt/masutaka-29hours/shared/29hours/vendor/bundle/ruby/2.2.0/gems/twitter-5.14.0/lib/twitter/streaming/client.rb:118:in `request'
        from /opt/masutaka-29hours/shared/29hours/vendor/bundle/ruby/2.2.0/gems/twitter-5.14.0/lib/twitter/streaming/client.rb:91:in `user'
        from /opt/masutaka-29hours/releases/20150829060219/29hours/lib/twenty_nine_hours.rb:72:in `start'
        from /opt/masutaka-29hours/releases/20150829060219/29hours/lib/twenty_nine_hours.rb:39:in `watch'
        from 29hours.rb:17:in `<main>'
```

Heroku の時に発生しなかったように見えるのは、Heroku のインスタンスが毎日作りなおされているから？

https://github.com/masutaka/29hours/tree/avoid-eoferror に変更して様子を見る。
当該コミットは https://github.com/masutaka/29hours/commit/41317fff34dc13a02404e079dc8832666465291b
